### PR TITLE
Add Tree-sitter configuration with syntax highlighting and text objects

### DIFF
--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -5,11 +5,3 @@
 vim.opt.foldmethod = "expr"
 vim.opt.foldexpr = "nvim_treesitter#foldexpr()"
 vim.opt.foldenable = false  -- Don't fold by default
-
--- Incremental selection keymaps
-local ts_repeat_move = require("nvim-treesitter.textobjects.repeatable_move")
-
--- Optional: configure text objects for better code navigation
--- These keymaps work with tree-sitter textobjects
-vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
-vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)

--- a/after/plugin/treesitter.lua
+++ b/after/plugin/treesitter.lua
@@ -1,0 +1,15 @@
+-- Tree-sitter configuration and keymaps
+-- Additional tree-sitter setup that runs after plugins are loaded
+
+-- Enable folding with tree-sitter
+vim.opt.foldmethod = "expr"
+vim.opt.foldexpr = "nvim_treesitter#foldexpr()"
+vim.opt.foldenable = false  -- Don't fold by default
+
+-- Incremental selection keymaps
+local ts_repeat_move = require("nvim-treesitter.textobjects.repeatable_move")
+
+-- Optional: configure text objects for better code navigation
+-- These keymaps work with tree-sitter textobjects
+vim.keymap.set({ "n", "x", "o" }, ";", ts_repeat_move.repeat_last_move_next)
+vim.keymap.set({ "n", "x", "o" }, ",", ts_repeat_move.repeat_last_move_previous)

--- a/lua/pedrosnk/lazy_plugins/treesitter.lua
+++ b/lua/pedrosnk/lazy_plugins/treesitter.lua
@@ -1,0 +1,37 @@
+return {
+  "nvim-treesitter/nvim-treesitter",
+  build = ":TSUpdate",
+  event = { "BufReadPre", "BufNewFile" },
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+  },
+  opts = {
+    ensure_installed = {
+      "c",
+      "cpp",
+      "ruby",
+      "python",
+      "erlang",
+      "elixir",
+      "rust",
+      "javascript",
+      "typescript",
+      "go",
+      "sql",
+      "lua",
+      "vim",
+      "vimdoc",
+    },
+    auto_install = true,
+    highlight = {
+      enable = true,
+      additional_vim_regex_highlighting = false,
+    },
+    indent = {
+      enable = true,
+    },
+  },
+  config = function(_, opts)
+    require("nvim-treesitter.configs").setup(opts)
+  end,
+}

--- a/lua/pedrosnk/lazy_plugins/treesitter.lua
+++ b/lua/pedrosnk/lazy_plugins/treesitter.lua
@@ -30,6 +30,38 @@ return {
     indent = {
       enable = true,
     },
+    textobjects = {
+      select = {
+        enable = true,
+        lookahead = true,
+        keymaps = {
+          ["af"] = "@function.outer",
+          ["if"] = "@function.inner",
+          ["ac"] = "@class.outer",
+          ["ic"] = "@class.inner",
+        },
+      },
+      move = {
+        enable = true,
+        set_jumps = true,
+        goto_next_start = {
+          ["]m"] = "@function.outer",
+          ["]]"] = "@class.outer",
+        },
+        goto_next_end = {
+          ["]M"] = "@function.outer",
+          ["]["] = "@class.outer",
+        },
+        goto_previous_start = {
+          ["[m"] = "@function.outer",
+          ["[["] = "@class.outer",
+        },
+        goto_previous_end = {
+          ["[M"] = "@function.outer",
+          ["[]"] = "@class.outer",
+        },
+      },
+    },
   },
   config = function(_, opts)
     require("nvim-treesitter.configs").setup(opts)


### PR DESCRIPTION
## Summary
This PR adds Tree-sitter integration to the Neovim configuration, enabling advanced syntax highlighting, code folding, and text object navigation capabilities.

## Changes
- **New plugin configuration** (`lua/pedrosnk/lazy_plugins/treesitter.lua`):
  - Added nvim-treesitter plugin with lazy loading on buffer read/new file events
  - Configured automatic installation for 13 language parsers (C, C++, Ruby, Python, Erlang, Elixir, Rust, JavaScript, TypeScript, Go, SQL, Lua, Vim)
  - Enabled syntax highlighting with Tree-sitter as the primary highlighter
  - Enabled Tree-sitter-based indentation
  - Added nvim-treesitter-textobjects as a dependency for enhanced code navigation

- **New post-plugin setup** (`after/plugin/treesitter.lua`):
  - Configured Tree-sitter expression-based code folding
  - Disabled folding by default to avoid performance impact on large files
  - Added keymaps for repeatable text object navigation (`;` for next, `,` for previous)

## Implementation Details
- Tree-sitter is lazy-loaded to improve startup time
- Auto-install is enabled to automatically download parsers for configured languages
- Additional Vim regex highlighting is disabled since Tree-sitter provides superior highlighting
- Repeatable move keymaps enhance navigation when using Tree-sitter text objects